### PR TITLE
Add tag subtree criterion

### DIFF
--- a/API/Repository/Values/Content/Query/Criterion/TagSubtree.php
+++ b/API/Repository/Values/Content/Query/Criterion/TagSubtree.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Netgen\TagsBundle\API\Repository\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+
+/**
+ * A criterion that matches content based on tag subtree that is located in one of the fields
+ *
+ * Supported operators:
+ * - IN: matches against a list of tag subtrees (with OR operator)
+ * - EQ: matches against one tag subtree
+ * - LIKE: matches against a part of tag subtree
+ */
+class TagSubtree extends Criterion implements CriterionInterface
+{
+    /**
+     * Creates a new TagSubtree criterion
+     *
+     * @param string $operator
+     * @param string|string[] $value One or more tag subtrees that must be matched
+     *
+     * @throws \InvalidArgumentException if a non string parameter is given
+     * @throws \InvalidArgumentException if the value type doesn't match the operator
+     */
+    public function __construct( $operator, $value )
+    {
+        parent::__construct( null, $operator, $value );
+    }
+
+    public function getSpecifications()
+    {
+        return array(
+            new Specifications(
+                Operator::IN,
+                Specifications::FORMAT_ARRAY,
+                Specifications::TYPE_STRING
+            ),
+            new Specifications(
+                Operator::EQ,
+                Specifications::FORMAT_SINGLE,
+                Specifications::TYPE_STRING
+            ),
+            new Specifications(
+                Operator::LIKE,
+                Specifications::FORMAT_SINGLE,
+                Specifications::TYPE_STRING
+            ),
+        );
+    }
+
+    public static function createFromQueryBuilder( $target, $operator, $value )
+    {
+        return new self( $operator, $value );
+    }
+}

--- a/Core/Persistence/Legacy/Content/Search/Common/Gateway/CriterionHandler/TagSubtree.php
+++ b/Core/Persistence/Legacy/Content/Search/Common/Gateway/CriterionHandler/TagSubtree.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Netgen\TagsBundle\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use Netgen\TagsBundle\API\Repository\Values\Content\Query\Criterion\TagSubtree as TagSubtreeCriterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+
+/**
+ * Tag subtree criterion handler
+ */
+class TagSubtree extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof TagSubtreeCriterion;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriteriaConverter $converter
+     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return \eZ\Publish\Core\Persistence\Database\Expression
+     */
+    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    {
+        $subSelect = $query->subSelect();
+        $subSelect
+            ->select( $this->dbHandler->quoteColumn( 'id', 'ezcontentobject' ) )
+            ->from( $this->dbHandler->quoteTable( 'ezcontentobject' ) )
+            ->innerJoin(
+                $this->dbHandler->quoteTable( 'eztags_attribute_link' ),
+                $subSelect->expr->lAnd(
+                    array(
+                        $subSelect->expr->eq(
+                            $this->dbHandler->quoteColumn( 'objectattribute_version', 'eztags_attribute_link' ),
+                            $this->dbHandler->quoteColumn( 'current_version', 'ezcontentobject' )
+                        ),
+                        $subSelect->expr->eq(
+                            $this->dbHandler->quoteColumn( 'object_id', 'eztags_attribute_link' ),
+                            $this->dbHandler->quoteColumn( 'id', 'ezcontentobject' )
+                        )
+                    )
+                )
+            )->innerJoin(
+                $this->dbHandler->quoteTable( 'eztags' ),
+                $subSelect->expr->eq(
+                    $this->dbHandler->quoteColumn( 'keyword_id', 'eztags_attribute_link' ),
+                    $this->dbHandler->quoteColumn( 'id', 'eztags' )
+                )
+            );
+
+        if ( $criterion->operator == Criterion\Operator::LIKE )
+        {
+            $subSelect->where(
+                $query->expr->like(
+                    $this->dbHandler->quoteColumn( 'path_string', 'eztags' ),
+                    $query->bindValue( $criterion->value[0] )
+                )
+            );
+        }
+        else
+        {
+            $subSelect->where(
+                $query->expr->in(
+                    $this->dbHandler->quoteColumn( 'path_string', 'eztags' ),
+                    $criterion->value
+                )
+            );
+        }
+
+        return $query->expr->in(
+            $this->dbHandler->quoteColumn( 'id', 'ezcontentobject' ),
+            $subSelect
+        );
+    }
+}
+

--- a/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/TagSubtree.php
+++ b/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/TagSubtree.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Netgen\TagsBundle\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use Netgen\TagsBundle\API\Repository\Values\Content\Query\Criterion\TagSubtree as TagSubtreeCriterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+
+/**
+ * Tag subtree criterion handler
+ */
+class TagSubtree extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof TagSubtreeCriterion;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
+     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
+     *
+     * @return \eZ\Publish\Core\Persistence\Database\Expression
+     */
+    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion, array $fieldFilters = null )
+    {
+        $subSelect = $query->subSelect();
+        $subSelect
+            ->select( $this->dbHandler->quoteColumn( 'id', 'ezcontentobject' ) )
+            ->from( $this->dbHandler->quoteTable( 'ezcontentobject' ) )
+            ->innerJoin(
+                $this->dbHandler->quoteTable( 'eztags_attribute_link' ),
+                $subSelect->expr->lAnd(
+                    array(
+                        $subSelect->expr->eq(
+                            $this->dbHandler->quoteColumn( 'objectattribute_version', 'eztags_attribute_link' ),
+                            $this->dbHandler->quoteColumn( 'current_version', 'ezcontentobject' )
+                        ),
+                        $subSelect->expr->eq(
+                            $this->dbHandler->quoteColumn( 'object_id', 'eztags_attribute_link' ),
+                            $this->dbHandler->quoteColumn( 'id', 'ezcontentobject' )
+                        )
+                    )
+                )
+            )->innerJoin(
+                $this->dbHandler->quoteTable( 'eztags' ),
+                $subSelect->expr->eq(
+                    $this->dbHandler->quoteColumn( 'keyword_id', 'eztags_attribute_link' ),
+                    $this->dbHandler->quoteColumn( 'id', 'eztags' )
+                )
+            );
+
+        if ( $criterion->operator == Criterion\Operator::LIKE )
+        {
+            $subSelect->where(
+                $query->expr->like(
+                    $this->dbHandler->quoteColumn( 'path_string', 'eztags' ),
+                    $query->bindValue( $criterion->value[0] )
+                )
+            );
+        }
+        else
+        {
+            $subSelect->where(
+                $query->expr->in(
+                    $this->dbHandler->quoteColumn( 'path_string', 'eztags' ),
+                    $criterion->value
+                )
+            );
+        }
+
+        return $query->expr->in(
+            $this->dbHandler->quoteColumn( 'id', 'ezcontentobject' ),
+            $subSelect
+        );
+    }
+}
+

--- a/Resources/config/storage_engines/legacy/search_query_handlers.yml
+++ b/Resources/config/storage_engines/legacy/search_query_handlers.yml
@@ -1,6 +1,7 @@
 parameters:
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.tag_id.class: Netgen\TagsBundle\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\TagId
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.tag_keyword.class: Netgen\TagsBundle\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\TagKeyword
+    ezpublish.persistence.legacy.search.gateway.criterion_handler.common.tag_subtree.class: Netgen\TagsBundle\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\TagSubtree
 
 services:
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.tag_id:
@@ -13,6 +14,13 @@ services:
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.tag_keyword:
         parent: ezpublish.persistence.legacy.search.gateway.criterion_handler.base
         class: %ezpublish.persistence.legacy.search.gateway.criterion_handler.common.tag_keyword.class%
+        tags:
+            - {name: ezpublish.persistence.legacy.search.gateway.criterion_handler.content}
+            - {name: ezpublish.persistence.legacy.search.gateway.criterion_handler.location}
+
+    ezpublish.persistence.legacy.search.gateway.criterion_handler.common.tag_subtree:
+        parent: ezpublish.persistence.legacy.search.gateway.criterion_handler.base
+        class: %ezpublish.persistence.legacy.search.gateway.criterion_handler.common.tag_subtree.class%
         tags:
             - {name: ezpublish.persistence.legacy.search.gateway.criterion_handler.content}
             - {name: ezpublish.persistence.legacy.search.gateway.criterion_handler.location}

--- a/Resources/config/storage_engines/legacy/search_query_handlers_new_namespaces.yml
+++ b/Resources/config/storage_engines/legacy/search_query_handlers_new_namespaces.yml
@@ -1,6 +1,7 @@
 parameters:
     ezpublish.search.legacy.gateway.criterion_handler.common.tag_id.class: Netgen\TagsBundle\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\TagId
     ezpublish.search.legacy.gateway.criterion_handler.common.tag_keyword.class: Netgen\TagsBundle\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\TagKeyword
+    ezpublish.search.legacy.gateway.criterion_handler.common.tag_subtree.class: Netgen\TagsBundle\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\TagSubtree
 
 services:
     ezpublish.search.legacy.gateway.criterion_handler.common.tag_id:
@@ -13,6 +14,13 @@ services:
     ezpublish.search.legacy.gateway.criterion_handler.common.tag_keyword:
         parent: ezpublish.search.legacy.gateway.criterion_handler.base
         class: %ezpublish.search.legacy.gateway.criterion_handler.common.tag_keyword.class%
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+
+    ezpublish.search.legacy.gateway.criterion_handler.common.tag_subtree:
+        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        class: %ezpublish.search.legacy.gateway.criterion_handler.common.tag_subtree.class%
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}


### PR DESCRIPTION
Hi,

I just wrote a criterion to fetch content based on a tag subtree and would like to share it with you.

I called it `TagSubtree` and not `TagPathString` criterion, because the criterion to fetch locations based on the `path_string` is called Subtree too.
## Example:

Tags structure:
- Mediums ( TagId: 1 )
  - DVD
  - BlueRay
  - CD

You can now fetch all products, they are tagged with either DVD, BlueRay or CD with something like:

``` PHP
$query->filter = new Criterion\LogicalAnd(
    array(
        new Criterion\ContentTypeIdentifier( 'product' ),
        new TagCriterion\TagSubtree( "/1/%" )
    )
 );
```

Best regards
