### PR TITLE
Fix Tag router causing ConfigResolver to be created to early by dep

### DIFF
--- a/Resources/config/papi.yml
+++ b/Resources/config/papi.yml
@@ -8,6 +8,7 @@ services:
 
     ezpublish.signalslot.service.tags:
         class: %ezpublish.signalslot.service.tags.class%
+        lazy: true
         arguments:
             - @ezpublish.api.service.tags.inner
             - @ezpublish.signalslot.signal_dispatcher


### PR DESCRIPTION
The tag router depends on ezpublish.api.service.tags which in turn causes the the ezpublish.api.storage_engine to be loaded which causes the ConfigResolverto be instantiated too early. 

See https://github.com/ezsystems/ezpublish-kernel/pull/1440 for some more detail.
