### PR TITLE
fix paths in schema import doc

### DIFF
--- a/Resources/doc/INSTALL.md
+++ b/Resources/doc/INSTALL.md
@@ -61,10 +61,10 @@ _eztagsRoutes:
 Netgen Tags Bundle uses custom database tables to store the tags. Use the following command to add the tables to your eZ Publish database:
 
 ```
-$ mysql -u<user> -p<password> -h<host> <db_name> < vendor/netgen/tagsbundle/Netgen/TagsBundle/Resources/sql/mysql/schema.sql
+$ mysql -u<user> -p<password> -h<host> <db_name> < vendor/netgen/tagsbundle/Resources/sql/mysql/schema.sql
 ```
 
-PostgreSQL variant of the above schema file is also available at `vendor/netgen/tagsbundle/Netgen/TagsBundle/Resources/sql/postgresql/schema.sql`
+PostgreSQL variant of the above schema file is also available at `vendor/netgen/tagsbundle/Resources/sql/postgresql/schema.sql`
 
 ### Clear the caches
 


### PR DESCRIPTION
Small change in doc, where you are told to import a sql file in a path that doesn't exist anymore, probably because of this change. 
https://github.com/crevillo/TagsBundle/commit/0c4ee7f12e0071c215d0e4fcf57ed414e0ccfc46

Let me know if i need to add an issue or something. 

ping @emodric  