### PR TITLE
Implement edit view for ez tags

### DIFF
--- a/Core/REST/Server/Controller/Tags.php
+++ b/Core/REST/Server/Controller/Tags.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
 use Netgen\TagsBundle\API\Repository\TagsService;
 use Netgen\TagsBundle\Core\REST\Server\Values;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 class Tags extends RestController
 {
@@ -540,5 +541,111 @@ class Tags extends RestController
         $pathParts = explode('/', trim($path, '/'));
 
         return array_pop($pathParts);
+    }
+
+
+    /**
+     * Function that returns a JSON Object including all available Tags in a list
+     *
+     * @param $hideRootTag - boolean: if true, all Tags of the root will be returned as well
+     *                       false: tags in root level will be hidden
+     * @param $subTreeLimit - Id of the root tag - if given all subtags of this tag will be returned,
+     *                       otherwise all Tags are returned
+     * @return JsonResponse - JSON formed arrey containing all selected tags
+     */
+    public function loadAllTags(Request $request, $subTreeLimit)
+    {
+        $tags = array();
+
+        $hideRootTag = $request->get('hideRootTag');
+
+        // get tag list of first level if parent tag is given ..
+        if (!empty($subTreeLimit)){
+
+            $rootTag = $this->tagsService->loadTag($subTreeLimit);
+
+            // show parent tag if needed
+            if ($hideRootTag === 'false'){
+                $mainLanguageCode = $rootTag->mainLanguageCode;
+                $tags[$rootTag->keywords[$mainLanguageCode]] =  $this->tagObjToArray($rootTag);
+            }
+            $rootTags = [$rootTag];
+
+        } else {
+            // no parent tag given.. get all tags..
+            $rootTags = $this->tagsService->loadTagChildren(null);
+
+            // show first level tags if needed
+            if ($hideRootTag === 'false'){
+
+                foreach($rootTags as $rootTag){
+                    $mainLanguageCode = $rootTag->mainLanguageCode;
+                    $tags[$rootTag->keywords[$mainLanguageCode]] =  $this->tagObjToArray($rootTag);
+                }
+            }
+        }
+
+        // get child tags
+        $res = array_merge($tags, $this->getChildTags($rootTags));
+
+        // create a JSON- list and return it.
+        return new JsonResponse(array('tagTree' => $res));
+    }
+
+
+    /**
+     *  Function that gets all childs of the next level of each tag passed as parameter
+     *  The childtags are returned in a same list, nevermind of the parent tag.
+     *
+     * @param $tags - array of (parent-) tagsobjects
+     * @return array of child objects
+     */
+    private function getChildTags($tags)
+    {
+        $results = array();
+
+        foreach($tags as $tag){
+
+            // get child tags of current tag
+            $tagAttrs = $this->tagsService->loadTagChildren($tag);
+
+            foreach($tagAttrs as $tagAttr){
+                $mainLanguageCode = $tagAttr->mainLanguageCode;
+
+                // 'translate' tagObject
+                $results[$tagAttr->keywords[$mainLanguageCode]] = $this->tagObjToArray($tagAttr);
+
+                // get the childtags and merge the results...
+                $results = array_merge($results, $this->getChildTags([$tagAttr]));
+            }
+        }
+        return $results;
+    }
+
+
+    /**
+     * function that transforms a tag object into an associative array. Indeed, the attributes of the
+     * tag object are protected and inaccessible for the JSON- converter
+     *
+     * @param $tag
+     * @return array
+     */
+    private function tagObjToArray($tag)
+    {
+        $result = array(
+            'id' => $tag->id,
+            'parent_id'   => $tag->parentTagId,
+            'main_tag_id' => $tag->mainTagId,
+            'keywords'    => $tag->keywords,
+            'depth'       => $tag->depth,
+            'path_string' => $tag->pathString,
+            'modified'    => date_format($tag->modificationDate, 'U'),
+            'remote_id'   => $tag->remoteId,
+            'always_available'   =>$tag->alwaysAvailable,
+            'main_language_code' => $tag->mainLanguageCode,
+            'language_codes' =>$tag->languageCodes
+        );
+
+        return $result;
     }
 }

--- a/Resources/config/platformui/yui.yml
+++ b/Resources/config/platformui/yui.yml
@@ -38,3 +38,12 @@ system:
                     path: bundles/netgentags/platformui/js/views/fields/templates/netgen-tags-field-view.hbt
                 ez-rawcontentview:
                     requires: ['netgen-tags-field-view']
+
+                netgen-tags-field-editview:
+                    requires: ['ez-fieldeditview', 'ez-selection-editview', 'event-valuechange', 'io-base', 'netgentagsfieldeditview-ez-template']
+                    path: bundles/netgentags/platformui/js/views/fields/netgen-tags-field-edit.js
+                netgentagsfieldeditview-ez-template:
+                    type: template
+                    path: bundles/netgentags/platformui/js/views/fields/templates/netgen-tags-field-edit.hbt
+                ez-contenteditformview:
+                    requires: ['netgen-tags-field-editview']

--- a/Resources/config/routing/rest.yml
+++ b/Resources/config/routing/rest.yml
@@ -103,3 +103,9 @@ ezpublish_rest_eztags_deleteTag:
     methods: [DELETE]
     requirements:
         tagPath: "[0-9/]+"
+
+ezpublish_rest_eztags_loadAllTags:
+    path: /tags-all/{subTreeLimit}
+    defaults:
+        _controller: eztags.rest.controller.tags:loadAllTags
+    methods: [GET]

--- a/Resources/public/platformui/js/views/fields/netgen-tags-field-edit.js
+++ b/Resources/public/platformui/js/views/fields/netgen-tags-field-edit.js
@@ -1,0 +1,257 @@
+/**
+ *  class that overides default behaviour for eztag fields.
+ *
+ */
+YUI.add('netgen-tags-field-editview', function (Y) {
+    "use strict";
+    /**
+     * Provides the field edit view for the ezTag fields
+     *
+     * @module netgen-tags-editview
+     */
+
+    Y.namespace('Netgen.Tags.Edit.Field');
+
+    // fieldidentifier to handle..
+    var FIELDTYPE_IDENTIFIER = 'eztags';
+
+    /**
+     * ez-tags edit view
+     *
+     * @namespace eZ
+     * @class tagsEditView
+     * @constructor
+     * @extends eZ.SelectionEditView
+     */
+    Y.Netgen.Tags.Edit.Field.TagsEdit = Y.Base.create('NetgenTagsFieldEditView', Y.eZ.SelectionEditView, [], {
+
+        _tagList: [],
+        _tagNames: [],
+
+        initializer: function () {
+            this._useStandardFieldDefinitionDescription = false;
+
+            this.containerTemplate = '<div class="' +
+                this._generateViewClassName(this._getName()) + ' ' +
+                this._generateViewClassName(Y.eZ.SelectionEditView.NAME) + '"/>';
+
+            var fieldDefinition = this.get('fieldDefinition');
+
+            // AJAX call in order to get the tagList if not available
+            var path = '/api/ezp/v2/tags-all/'+fieldDefinition.fieldSettings.subTreeLimit +'?hideRootTag='+fieldDefinition.fieldSettings.hideRootTag;
+            Y.io(path, {
+                method: 'GET',
+                on: {
+                    success: Y.bind(this._handleResponse, this),
+                    failure: this._handleLoadFailure,
+                },
+                context: this
+            });
+        },
+
+
+        /**
+         * Handles the Ajax response and stores the returned list of all available tags..
+         *
+         * @method _handleFormSubmitResponse
+         * @param {XMLHttpRequest} response
+         */
+        _handleResponse: function (transactionId, ajax) {
+            var tags = JSON.parse(ajax.response);
+
+            this._tagList = tags.tagTree;
+
+            // save the tagsname of each tag ..
+            var tagNames = [];
+            for (var tagname in tags.tagTree){
+                tagNames.push(tagname);
+            }
+
+            // sort the list..
+            tagNames.sort(function(strA, strB) {
+                // .. upper - and lowercases are not correctly ordered.. so lowercase all of them during sorting..
+                return strA.toLowerCase().localeCompare(strB.toLowerCase());
+            });
+
+            // format the values in order to handle them directly by the searchbox..
+            var res = [];
+            for (var i = 0; i < tagNames.length; i++) {
+                res.push({
+                    Name: tagNames[i]
+                });
+            }
+
+            // store the tagnames in config..
+            this._tagNames = res;
+        },
+
+
+        /**
+         * Handles the loading error.
+         *
+         * @method _handleLoadFailure
+         * @param {String} tId
+         * @param {XMLHttpRequest} response
+         * @protected
+         */
+        _handleLoadFailure: function (tId, response) {
+            var frag = Y.Node.create(response.responseText),
+                notificationCount,
+                errorMsg = '';
+
+            this.get('app').set('loading', false);
+            notificationCount = this._parseNotifications(frag);
+            if ( notificationCount === 0 ) {
+                errorMsg = "Failed to load '" + response.responseURL + "'";
+            }
+            this._error(errorMsg);
+        },
+
+
+        /**
+         * function that gets the keyword from the tag object and returns it ..
+         *
+         * @param tag
+         * @returns string
+         * @private
+         */
+        _getTagName: function(tag) {
+            var mainLanguageCode = tag.main_language_code;
+            return tag.keywords[mainLanguageCode];
+        },
+
+
+
+        /**
+         * function that initializes the selection component..
+         *
+         * @returns {Y.eZ.SelectionFilterView}
+         * @private
+         */
+        _getSelectionFilter: function () {
+
+            var container = this.get('container'),
+                selectedObjectArray = this._getSelectedTextValues(),
+                input = container.one('.ez-selection-filter-input'),
+                source = this._tagNames,
+                selected = [];
+
+            Y.Array.each(selectedObjectArray, function (selectedObject) {
+                selected.push(selectedObject.text);
+            });
+            return new Y.eZ.SelectionFilterView({
+                container: input.get('parentNode'),
+                inputNode: input,
+                listNode: this.get('container').one('.ez-selection-options'),
+                selected: selected,
+                source: source,
+                filter: true,
+                resultFilters: 'startsWith',
+                resultHighlighter: 'startsWith',
+                isMultiple: true,
+                resultTextLocator: function (sourceElement) {
+                    return sourceElement.Name;
+                },
+                resultAttributesFormatter: function (sourceElement) {
+                    return {
+                        text: sourceElement.Name
+                    };
+                }
+            });
+        },
+
+
+        /**
+         * Validates the current input of eztag field field
+         *
+         * @method validate
+         */
+        validate: function () {
+
+            // config of the field
+            var fieldDefinition = this.get('fieldDefinition');
+
+            // fieldvalues..
+            var values = this.get('values');
+
+            // no Tag is given, but it should...
+            if ((values.length==0)&&(fieldDefinition.isRequired)){
+                this.set('errorStatus', 'This field is required');
+            }
+
+            // more tags given than allowed..
+            else if (  (0<fieldDefinition.fieldSettings.maxTags)
+                     &&(fieldDefinition.fieldSettings.maxTags < values.length)) {
+                this.set('errorStatus', 'To many tags');
+            }
+
+            // no error
+            else {
+                this.set('errorStatus', false);
+            }
+        },
+
+
+
+        /**
+         * function that returns list of keywords from selected tags.
+         * the returned values are used for the display in textbox.
+         *
+         * @returns {Array} of objects containing  - keywords from selected tags..
+         * @private
+         */
+        _getSelectedTextValues: function () {
+            var field = this.get('field'),
+                fieldTagsObjs = [],
+                res = [];
+
+            // get the fieldvalues..
+            if ( field && field.fieldValue ) {
+                fieldTagsObjs = field.fieldValue;
+            }
+
+            // get the keywords from the tag object and create a key/value pair..
+            for (var i = 0; i < fieldTagsObjs.length; i++) {
+                res.push({
+                    text: this._getTagName(fieldTagsObjs[i])
+                });
+            }
+            return res;
+        },
+
+
+        /**
+         *  function that translates the selected values into tag objects.
+         *  this function is called just before saving the dataset of the content object.
+         * @returns {Array} of tagobjects
+         * @private
+         */
+        _getFieldValue: function () {
+
+            // get config in order to access to the tagobjects list
+            var config = this.get('config');
+
+            // get the fieldvalues..
+            var values = this.get('values');
+
+            // get the tag objects corresponding
+            var res = [];
+            for (var i = 0; i < values.length; i++) {
+                // value is issued from initial value
+                if (values[i].text){
+                    res.push(this._tagList[values[i].text]);
+
+                // value has been added trough cumbobox..
+                } else if (typeof values[i] == 'string'){
+                    res.push(this._tagList[values[i]]);
+                }
+            }
+            // array of tag objects..
+            return res;
+        }
+    });
+
+
+    // link js class to ez field. ...
+    Y.eZ.FieldEditView.registerFieldEditView(FIELDTYPE_IDENTIFIER, Y.Netgen.Tags.Edit.Field.TagsEdit);
+});

--- a/Resources/public/platformui/js/views/fields/templates/netgen-tags-field-edit.hbt
+++ b/Resources/public/platformui/js/views/fields/templates/netgen-tags-field-edit.hbt
@@ -1,0 +1,26 @@
+<div class="pure-g ez-editfield-row">
+    <div class="pure-u ez-editfield-infos">
+        <label for="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
+            <p class="ez-fielddefinition-name">
+                {{ translate_property fieldDefinition.names }}{{#if isRequired}}*{{/if}}:
+            </p>
+            <p class="ez-editfield-error-message">&nbsp;</p>
+        </label>
+    </div>
+    <div class="pure-u ez-editfield-input-area ez-default-error-style">
+        <div class="ez-editfield-input">
+            <div class="ez-selection-input-ui" id="ez-field-{{ content.contentId }}-{{ fieldDefinition.identifier }}">
+                <ul class="ez-selection-values">
+                    {{#each selected}}
+                        <li class="ez-selection-value" data-text="{{text}}" >{{text}}</li>
+                    {{/each}}
+                </ul>
+                <div class="ez-selection-list">
+                    <input type="text" class="ez-selection-filter-input" placeholder="Filter the option list">
+                    <ul class="ez-selection-options"></ul>
+                </div>
+            </div>
+        </div>
+        {{> ez_fielddescription_tooltip }}
+    </div>
+</div>


### PR DESCRIPTION
This feature implements tags handeling while editing a content. Therefore it is possible, search (autocompleted), add or remove a tag. The solution is based on ez selection, same one which is already used for the field type of the countries - so no additional (JQuery-) components where used. 

The settins of the field definition of the content types are used (except for settings of the view selection - default, select and treeview). If a parent tag is selected, all children tags are returned. If the checkbox 'hide root..' is selected, the parent tag is not returned. If there is no parent tag no tags of the first level are returned (we required this behaviour for our project). We also added a new function in REST controller, returning all selected tag objects as a list of JSON objects. These meet the requirements to be saved by ez-API. 

## known issues

* Only the keywords of the mainlanguage are displayed in frontend. 
* The list displayed in the combo selection is an alphabetically ordered list of the keywords. Before saving we are searching for the corresponding object by its keyword. Therefore, it is currently not possible to use the same keyword in different tags.