### PR TITLE
[Composer] Add type: "ezplatform-bundle" to 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "netgen/tagsbundle",
     "description": "Netgen Tags Bundle is an eZ Platform / eZ Publish bundle for taxonomy management and easier classification of content, providing more functionality for tagging content than ezkeyword field type included in eZ Publish kernel.",
     "license": "GPL-2.0",
+    "type": "ezplatform-bundle",
     "authors": [
         {
             "name": "Netgen",


### PR DESCRIPTION
Makes it possible to query ezplatform bundles via packagist: https://packagist.org/packages/list.json?type=ezplatform-bundle

A future version of projects.ez.no, will use such queries to index all bundles, including those not manually listed.