### PR TITLE
Order column should be in select

### DIFF
--- a/Core/Persistence/Legacy/Tags/Gateway/DoctrineDatabase.php
+++ b/Core/Persistence/Legacy/Tags/Gateway/DoctrineDatabase.php
@@ -1047,7 +1047,7 @@ class DoctrineDatabase extends Gateway
     {
         /** @var $query \eZ\Publish\Core\Persistence\Database\SelectQuery */
         $query = $this->handler->createSelectQuery();
-        $query->select('DISTINCT eztags.id')
+        $query->select('DISTINCT eztags.id, eztags.keyword')
         ->from(
             $this->handler->quoteTable('eztags')
         )


### PR DESCRIPTION
Currently keyword column is missing from select query in `DoctrineDatabase.php`, with this fix query is properly generated:

```sql
SELECT DISTINCT eztags.id, eztags.keyword
FROM `eztags`
  LEFT JOIN `eztags_keyword`
    ON ( `eztags_keyword`.`keyword_id` = `eztags`.`id` AND `eztags_keyword`.`status` = 1 )
WHERE ( `eztags`.`parent_id` = 0
AND `eztags`.`main_tag_id` = 0 )
ORDER BY `eztags`.`keyword` ASC
LIMIT 25 OFFSET 0;
```