### PR TITLE
Add permission settings to the installation instructions

### DIFF
--- a/bundle/Resources/doc/INSTALL.md
+++ b/bundle/Resources/doc/INSTALL.md
@@ -72,6 +72,10 @@ Clear the eZ Platform caches with the following command:
 $ php bin/console cache:clear
 ```
 
+### Update Anonymous Role permissions
+
+Give the Anonymous Role 'Read' permissions to the `Tags` module.
+
 ### Install and dump assets
 
 Run the following to correctly install and dump assets for admin UI. Make sure to use the correct Symfony environment with `--env` parameter:


### PR DESCRIPTION
Without the anonymous role having read access to the tags module, templates trying to display tags will display an error. 