### PR TITLE
Change Admin UI Menu name to be just "Tags"

### DIFF
--- a/bundle/Resources/translations/eztags_admin.en.yml
+++ b/bundle/Resources/translations/eztags_admin.en.yml
@@ -1,4 +1,4 @@
-menu.main_menu.header: 'Netgen Tags'
+menu.main_menu.header: 'Tags'
 
 pagelayout.title: 'Netgen Tags'
 pagelayout.you_are_here: 'You are here'


### PR DESCRIPTION
Talked to Ivo some time back on this, and by now since all other tabs don't contain any vendor name _(same now also with eZ Commerce, it's "eCommerce")_. So herby proposing to also align naming in Tags bundle, as a bonus it saves some menu space :P

<img width="563" alt="screenshot 2018-10-04 at 21 44 24" src="https://user-images.githubusercontent.com/289757/46498963-1e23bc80-c81f-11e8-8589-5afc1f49979a.png">

_Side: Seems we should do some effort to start to translate Tags bundle_ /cc @bdunogier