### PR TITLE
Styled input fields and buttons to match eZ Platform's styling

### DIFF
--- a/bundle/Resources/public/admin/css/field/tagssuggest.css
+++ b/bundle/Resources/public/admin/css/field/tagssuggest.css
@@ -1,10 +1,28 @@
 /* SUGGEST */
 
 .ng-tags-input-ui .tagssuggestfieldwrap {float:left; position:relative; width:300px; margin:0 6px 0 0; vertical-align:top;}
-.ng-tags-input-ui .tagssuggestfield {width:100%; height:20px; margin:0; padding:1px 0; position:relative;/* border:1px solid #A5ACB2;*/}
 .ng-tags-input-ui .tags-output {display:block;}
 .ng-tags-input-ui .tags-input {clear: both; display:block;}
 .ng-tags-input-ui fieldset .button-add-tag {margin:0;}
+
+.ng-tags-input-ui .tagssuggestfield {
+    position:relative;
+    width: 100%;
+    padding: 0.375rem 0.75rem;
+    font-size: 1rem;
+    line-height: 1.5;
+    color: #333333;
+    background-color: #fff;
+    background-clip: padding-box;
+    border: 1px solid #ededed;
+    border-radius: 0.25rem;
+    transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.ng-tags-input-ui .tagssuggestfield:focus {
+    outline: 0;
+    box-shadow: 0 0 0 0.2rem rgba(241, 90, 16, 0.25);
+}
 
 .ng-tags-input-ui .jsonSuggestResults {
     display: none;

--- a/bundle/Resources/public/admin/css/field/tagssuggest.css
+++ b/bundle/Resources/public/admin/css/field/tagssuggest.css
@@ -19,6 +19,28 @@
     transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
+.ng-tags-input-ui button.button-add-tag {
+    color: #fff;
+    background-color: #f15a10;
+    border-color: #f15a10;
+    display: inline-block;
+    font-weight: 400;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    user-select: none;
+    border: 1px solid transparent;
+    padding: 0.375rem 0.75rem;
+    font-size: 1rem;
+    line-height: 1.5;
+    border-radius: 0.25rem;
+    transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.ng-tags-input-ui button.button-add-tag.button-disabled {
+    background-color: rgba(241, 90, 16, 0.7);
+}
+
 .ng-tags-input-ui .tagssuggestfield:focus {
     outline: 0;
     box-shadow: 0 0 0 0.2rem rgba(241, 90, 16, 0.25);


### PR DESCRIPTION
This is just a suggestion to keep things consistent.

Before:
![image](https://user-images.githubusercontent.com/14874283/50336251-f5ea5680-050d-11e9-9741-43fc90f2dbc6.png)

After:
![image](https://user-images.githubusercontent.com/14874283/50336233-ed921b80-050d-11e9-85c4-bebd6ec9a71f.png)