### PR TITLE
Added missing styling, fixed a bug where the label would break

### DIFF
--- a/bundle/Resources/public/admin/css/field/tagssuggest.css
+++ b/bundle/Resources/public/admin/css/field/tagssuggest.css
@@ -19,7 +19,8 @@
     transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
-.ng-tags-input-ui button.button-add-tag {
+.ng-tags-input-ui button.button-add-tag,
+.ng-tags-input-ui input.button-add-tag {
     color: #fff;
     background-color: #f15a10;
     border-color: #f15a10;
@@ -37,8 +38,14 @@
     transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
-.ng-tags-input-ui button.button-add-tag.button-disabled {
+.ng-tags-input-ui button.button-add-tag.button-disabled,
+.ng-tags-input-ui input.button-add-tag.button-disabled {
     background-color: rgba(241, 90, 16, 0.7);
+}
+
+.ng-tags-input-ui button.button-add-tag:not(.button-disabled):hover,
+.ng-tags-input-ui input.button-add-tag:not(.button-disabled):hover {
+    cursor: pointer;
 }
 
 .ng-tags-input-ui .tagssuggestfield:focus {

--- a/bundle/Resources/public/admin/css/field/tagssuggest.css
+++ b/bundle/Resources/public/admin/css/field/tagssuggest.css
@@ -2,7 +2,7 @@
 
 .ng-tags-input-ui .tagssuggestfieldwrap {float:left; position:relative; width:300px; margin:0 6px 0 0; vertical-align:top;}
 .ng-tags-input-ui .tags-output {display:block;}
-.ng-tags-input-ui .tags-input {clear: both; display:block;}
+.ng-tags-input-ui .tags-input {clear: both; display:inline-block;}
 .ng-tags-input-ui fieldset .button-add-tag {margin:0;}
 
 .ng-tags-input-ui .tagssuggestfield {


### PR DESCRIPTION
If a user does not have the privileges to add tags, the labels would break like shown here
![image](https://user-images.githubusercontent.com/14874283/50640556-804aa580-0f65-11e9-8a99-b5f2eb366be1.png)

#d0bf2fe should fix that.

Also added missing styling to elements that were styled in my previous PR. Both `<button>` and `<input/>` elements with the `.button-add-tag` class should be properly styled now.
Also added missing `cursor: pointer` to these elements.