### PR TITLE
Issue #76 : Removing eZDemo references from the bundle

### DIFF
--- a/bundle/DependencyInjection/Configuration.php
+++ b/bundle/DependencyInjection/Configuration.php
@@ -42,7 +42,7 @@ class Configuration extends SiteAccessConfiguration
                     ->scalarNode('pagelayout')
                         ->info('Default pagelayout used in tag view page')
                         ->cannotBeEmpty()
-                        ->defaultValue('@eZDemo/pagelayout.html.twig')
+                        ->defaultValue('@ezdesign/pagelayout.html.twig')
                     ->end()
                     ->scalarNode('path_prefix')
                         ->info('Default path prefix to use when generating tag view links')

--- a/bundle/Resources/config/default_settings.yml
+++ b/bundle/Resources/config/default_settings.yml
@@ -22,7 +22,7 @@ parameters:
     eztags.default.tag_view.template: '@@NetgenTags/tag/view.html.twig'
 
     # Default pagelayout used in tag view page
-    eztags.default.tag_view.pagelayout: '@@eZDemo/pagelayout.html.twig'
+    eztags.default.tag_view.pagelayout: '@@ezdesign/pagelayout.html.twig'
 
     # Default path prefix to use when generating tag view links
     # Since it's NOT recommended to use empty path prefix here,

--- a/bundle/Resources/config/ezplatform.yml
+++ b/bundle/Resources/config/ezplatform.yml
@@ -1,4 +1,7 @@
 system:
+    admin_group:
+        field_templates:
+            - {template: "@NetgenTags/admin/eztags_content_field.html.twig", priority: 1}
     default:
         field_templates:
             - {template: "@NetgenTags/eztags_content_field.html.twig", priority: 0}

--- a/bundle/Resources/views/admin/eztags_content_field.html.twig
+++ b/bundle/Resources/views/admin/eztags_content_field.html.twig
@@ -1,0 +1,7 @@
+{% block eztags_field %}
+{% spaceless %}
+    {% for tag in field.value.tags %}
+        <a href="{{ path('netgen_tags_admin_tag_show', {'tagId': tag.id}) }}">{{ netgen_tags_tag_keyword( tag ) }}</a>{% if not loop.last %}, {% endif %}
+    {% endfor %}
+{% endspaceless %}
+{% endblock %}


### PR DESCRIPTION
Following issue #76 , here is an attempt to avoid the bug happening in the admin part.

You said to me about the broken admin links solution : 
> However, this is not a bulletproof solution. Every new siteaccess (for example, customer specific admin panels) or custom panels that integrate with Tags Bundle, should need to add such a config, but that is a trivial fix, so maybe not a real issue.

I do think that new admin panels would be registered in the admin group, so would not encounter the problem. If that's not the case, then they will have the problem and then your proposition with `ezpublish.configResolver.parameter('pagelayout')` will globally solve it.

For this second part, instead of using the `ezpublish.configResolver.parameter('pagelayout')` directly, I choose to just change in the config the reference to ezdemo so that it goes to ezdesign now. this should allow users more flexibility to override and tweak with the functionality (if I'm not mistaken).

I tested quite a bit and nothing went wrong on my side, but then again I am not familiar with the inner workings and functionalities of the bundle, so sorry if I overlooked things. I hope this contribution is OK.

Big thanks to everyone working on this fantastic bundle!