### PR TITLE
Sort tags by keyword instead of ID

### DIFF
--- a/bundle/Core/Persistence/Legacy/Tags/Gateway/DoctrineDatabase.php
+++ b/bundle/Core/Persistence/Legacy/Tags/Gateway/DoctrineDatabase.php
@@ -337,7 +337,7 @@ class DoctrineDatabase extends Gateway
                 $tagIds
             )
         );
-        $query->orderBy('eztags.keyword', 'ASC');
+        $query->orderBy('eztags_keyword.keyword', 'ASC');
 
         $statement = $query->prepare();
         $statement->execute();

--- a/bundle/Core/Persistence/Legacy/Tags/Gateway/DoctrineDatabase.php
+++ b/bundle/Core/Persistence/Legacy/Tags/Gateway/DoctrineDatabase.php
@@ -337,6 +337,7 @@ class DoctrineDatabase extends Gateway
                 $tagIds
             )
         );
+        $query->orderBy('eztags.keyword', 'ASC');
 
         $statement = $query->prepare();
         $statement->execute();


### PR DESCRIPTION
The tags are currently being sorted by their ID, which doesn't make a whole lot of sense for the average user.

This PR will sort all tags by their keyword, ASC.