### PR TITLE
[WIP] V2 in-memory caching for tags loading

### DIFF
--- a/bundle/API/Repository/TagsService.php
+++ b/bundle/API/Repository/TagsService.php
@@ -25,6 +25,21 @@ interface TagsService
     public function loadTag($tagId, array $languages = null, $useAlwaysAvailable = true);
 
     /**
+     * Loads a tag object from array of $tagIds.
+     *
+     * Tags missing (NotFound), or not accessible (Unauthorized) to the current user will be filtered out from the
+     * returned array. As returned array has tag id's as keys, you can use array_keys + array_diff to get missing items
+     *
+     *
+     * @param array $tagIds
+     * @param array|null $languages A language filter for keywords. If not given all languages are returned
+     * @param bool $useAlwaysAvailable Add main language to $languages if true (default) and if tag is always available
+     *
+     * @return \Netgen\TagsBundle\API\Repository\Values\Tags\Tag[] Key of array is the corresponding tag id
+     */
+    public function loadTagList(array $tagIds, array $languages = null, $useAlwaysAvailable = true);
+
+    /**
      * Loads a tag object from its $remoteId.
      *
      * @param string $remoteId

--- a/bundle/Core/Persistence/Cache/TagsHandler.php
+++ b/bundle/Core/Persistence/Cache/TagsHandler.php
@@ -2,6 +2,7 @@
 
 namespace Netgen\TagsBundle\Core\Persistence\Cache;
 
+use eZ\Publish\Core\Persistence\Cache\AbstractInMemoryHandler;
 use eZ\Publish\Core\Persistence\Cache\PersistenceLogger;
 use Netgen\TagsBundle\SPI\Persistence\Tags\CreateStruct;
 use Netgen\TagsBundle\SPI\Persistence\Tags\Handler as TagsHandlerInterface;
@@ -9,30 +10,24 @@ use Netgen\TagsBundle\SPI\Persistence\Tags\SynonymCreateStruct;
 use Netgen\TagsBundle\SPI\Persistence\Tags\UpdateStruct;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 
-class TagsHandler implements TagsHandlerInterface
+class TagsHandler extends AbstractInMemoryHandler implements TagsHandlerInterface
 {
     const ALL_TRANSLATIONS_KEY = '0';
-
-    /**
-     * @var \Symfony\Component\Cache\Adapter\TagAwareAdapterInterface
-     */
-    protected $cache;
 
     /**
      * @var \Netgen\TagsBundle\SPI\Persistence\Tags\Handler
      */
     protected $tagsHandler;
 
-    /**
-     * @var \eZ\Publish\Core\Persistence\Cache\PersistenceLogger
-     */
-    protected $logger;
-
-    public function __construct(TagAwareAdapterInterface $cache, TagsHandlerInterface $tagsHandler, PersistenceLogger $logger)
-    {
-        $this->cache = $cache;
+    public function __construct(
+        TagAwareAdapterInterface $cache,
+        PersistenceLogger $logger,
+        $inMemory,
+        TagsHandlerInterface $tagsHandler
+    ) {
+        // No type hint on internal classes, parent::__construct will take care of checking that it gets what it expects.
+        parent::__construct($cache, $logger, $inMemory);
         $this->tagsHandler = $tagsHandler;
-        $this->logger = $logger;
     }
 
     public function load($tagId, array $translations = null, $useAlwaysAvailable = true)

--- a/bundle/Core/Persistence/Legacy/Tags/Handler.php
+++ b/bundle/Core/Persistence/Legacy/Tags/Handler.php
@@ -60,6 +60,23 @@ class Handler implements BaseTagsHandler
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function loadList(array $tagIds, array $translations = null, $useAlwaysAvailable = true)
+    {
+        // @todo This can be optimized in the future by adding method on gateway to load several
+        $tags = array();
+        foreach ($tagIds as $tagId) {
+            $rows = $this->gateway->getFullTagData($tagId, $translations, $useAlwaysAvailable);
+            if (!empty($rows)) {
+                $tags[(int) $tagId] = $this->mapper->extractTagListFromRows($rows)[0];
+            }
+        }
+
+        return $tags;
+    }
+
+    /**
      * Loads a tag info object from its $tagId.
      *
      * @param mixed $tagId

--- a/bundle/Core/SignalSlot/TagsService.php
+++ b/bundle/Core/SignalSlot/TagsService.php
@@ -60,6 +60,14 @@ class TagsService implements TagsServiceInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function loadTagList(array $tagIds, array $languages = null, $useAlwaysAvailable = true)
+    {
+        return $this->service->loadTagList($tagIds, $languages, $useAlwaysAvailable);
+    }
+
+    /**
      * Loads a tag object from its $remoteId.
      *
      * @param string $remoteId

--- a/bundle/Resources/config/storage/cache_psr6.yml
+++ b/bundle/Resources/config/storage/cache_psr6.yml
@@ -1,8 +1,6 @@
 services:
     eztags.api.persistence_handler.tags.cache:
+        parent: ezpublish.spi.persistence.cache.abstractInMemoryHandler
         class: Netgen\TagsBundle\Core\Persistence\Cache\TagsHandler
         public: false
-        arguments:
-            - "@ezpublish.cache_pool"
-            - "@eztags.api.persistence_handler.tags.storage"
-            - "@ezpublish.spi.persistence.cache.persistenceLogger"
+        arguments: ["@eztags.api.persistence_handler.tags.storage"]

--- a/bundle/SPI/Persistence/Tags/Handler.php
+++ b/bundle/SPI/Persistence/Tags/Handler.php
@@ -22,6 +22,19 @@ interface Handler
     public function load($tagId, array $translations = null, $useAlwaysAvailable = true);
 
     /**
+     * Loads a tag object from array of $tagIds.
+     *
+     * Tags missing (NotFound) will be filtered out from the returned array.
+     *
+     * @param array $tagIds
+     * @param array|null $translations A language filter for keywords. If not given all languages are returned
+     * @param bool $useAlwaysAvailable Add main language to $languages if true (default) and if tag is always available
+     *
+     * @return \Netgen\TagsBundle\SPI\Persistence\Tags\Tag[] Key of array is the corresponding tag id
+     */
+    public function loadList(array $tagIds, array $translations = null, $useAlwaysAvailable = true);
+
+    /**
      * Loads a tag info object from its $tagId.
      *
      * @param mixed $tagId

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^5.6|^7.1",
-        "ezsystems/ezpublish-kernel": "^6.11@dev|^7.0@dev",
+        "ezsystems/ezpublish-kernel": "^6.13@dev|^7.5@dev",
         "ezsystems/repository-forms": "^1.9|^2.0",
         "ezsystems/ezplatform-solr-search-engine": "^1.4@dev",
         "lolautruche/ez-core-extra-bundle": "^2.0",

--- a/tests/Core/FieldType/TagsTest.php
+++ b/tests/Core/FieldType/TagsTest.php
@@ -4,7 +4,6 @@ namespace Netgen\TagsBundle\Tests\Core\FieldType;
 
 use DateTime;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
-use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\FieldType\Tests\FieldTypeTest;
 use eZ\Publish\Core\FieldType\ValidationError;
 use Netgen\TagsBundle\API\Repository\TagsService;
@@ -29,23 +28,26 @@ class TagsTest extends FieldTypeTest
     /**
      * Returns values for TagsService::loadTag based on input value.
      *
-     * @param int $tagId
+     * @param array $tagIds
      *
-     * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException
-     *
-     * @return \Netgen\TagsBundle\API\Repository\Values\Tags\Tag
+     * @return \Netgen\TagsBundle\API\Repository\Values\Tags\Tag[]
      */
-    public function getTagsServiceLoadTagValues($tagId)
+    public function getTagsServiceLoadTagValues(array $tagIds)
     {
-        if ($tagId < 0 || $tagId === PHP_INT_MAX) {
-            throw new NotFoundException('tag', $tagId);
+        $tags = array();
+        foreach ($tagIds as $tagId) {
+            if ($tagId < 0 || $tagId === PHP_INT_MAX) {
+                continue;
+            }
+
+            $tags[$tagId] = new Tag(
+                array(
+                    'id' => $tagId,
+                )
+            );
         }
 
-        return new Tag(
-            array(
-                'id' => $tagId,
-            )
-        );
+        return $tags;
     }
 
     /**
@@ -576,7 +578,7 @@ class TagsTest extends FieldTypeTest
         $this->tagsService = $this->createMock(TagsService::class);
 
         $this->tagsService->expects($this->any())
-            ->method('loadTag')
+            ->method('loadTagList')
             ->will($this->returnCallback(array($this, 'getTagsServiceLoadTagValues')));
 
         $tagsType = new TagsType($this->tagsService);


### PR DESCRIPTION
WIP until v2 is out and we can remove dependency on schema package in unstable stability as well as changes to in-memory abstract. Once that is done this can be rebased on 3.3 if wanted.

Reduces tags loaded on for instance `admin/dashboard` with ee demo from about 424 cache lookups to 24.

Depends on https://github.com/ezsystems/ezpublish-kernel/pull/2586