### PR TITLE
Make nameable field type services public

### DIFF
--- a/bundle/Resources/config/fieldtypes.yml
+++ b/bundle/Resources/config/fieldtypes.yml
@@ -29,7 +29,7 @@ services:
 
     eztags.field_type.eztags.nameable:
         class: Netgen\TagsBundle\Core\FieldType\Tags\NameableField
-        public: false
+        public: true
         tags:
             - { name: ezpublish.fieldType.nameable, alias: eztags }
 

--- a/tests/settings/integration/legacy.yml
+++ b/tests/settings/integration/legacy.yml
@@ -11,4 +11,4 @@ services:
 
     eztags.field_type.eztags.nameable:
         class: Netgen\TagsBundle\Core\FieldType\Tags\NameableField
-        public: false
+        public: true


### PR DESCRIPTION
When editing eZ content on frontend, it complains about this service not being public.