### PR TITLE
fix for #119: Tag route generation in template fails

### DIFF
--- a/bundle/Resources/views/eztags_content_field.html.twig
+++ b/bundle/Resources/views/eztags_content_field.html.twig
@@ -1,5 +1,5 @@
 {% block eztags_field %}
     {% for tag in field.value.tags %}
-        <a href="{{ path(tag) }}">{{ tag.keyword }}</a>{% if not loop.last %}, {% endif %}
+        <a href="{{ path('eztags_tag_url', {'tagId': tag.id}) }}">{{ tag.keyword }}</a>{% if not loop.last %}, {% endif %}
     {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Path generation works fine with more verbous syntax defining route explicitly + params:

`{{ path(tag) }}`

vs. 

`{{ path('eztags_tag_url', {'tagId': tag.id}) }}`