### PR TITLE
Fix search field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ yarn.lock
 package-lock.json
 phpunit.phar
 .php_cs.cache
+.php-cs-fixer.cache
 .phpunit.result.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,6 +1,6 @@
 <?php
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PhpCsFixer' => true,
@@ -20,6 +20,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_no_alias_tag' => false,
         'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
         'single_line_comment_style' => false,
+        'visibility_required' => ['elements' => ['property', 'method']],
         'yoda_style' => false,
 
         // Additional rules
@@ -28,8 +29,7 @@ return PhpCsFixer\Config::create()
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()
-            ->exclude(['vendor', 'node_modules'])
-            ->notPath('bootstrap.php')
+            ->exclude(['vendor', 'node_modules', 'var'])
             ->in(__DIR__)
     )
 ;

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -8,7 +8,6 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 $kernelDir = __DIR__ . '/vendor/ezsystems/ezpublish-kernel';
 
 // Get global config.php settings

--- a/bundle/Controller/Admin/TreeController.php
+++ b/bundle/Controller/Admin/TreeController.php
@@ -97,7 +97,7 @@ class TreeController extends Controller
         } else {
             $configResolver = $this->getConfigResolver();
             $treeLimit = $configResolver->getParameter('admin.tree_limit', 'eztags');
-            $childrenTags = $this->tagsService->loadTagChildren($tag, 0 , $treeLimit > 0 ? $treeLimit : -1);
+            $childrenTags = $this->tagsService->loadTagChildren($tag, 0, $treeLimit > 0 ? $treeLimit : -1);
             foreach ($childrenTags as $tag) {
                 $result[] = $this->getTagTreeData($tag, $isRoot);
             }

--- a/bundle/Core/FieldType/Tags/SearchField.php
+++ b/bundle/Core/FieldType/Tags/SearchField.php
@@ -59,7 +59,7 @@ class SearchField implements Indexable
             new Search\Field(
                 'tag_text',
                 implode(' ', $tagKeywords),
-                new Search\FieldType\TextField()
+                new Search\FieldType\StringField()
             ),
             new Search\Field(
                 'fulltext',
@@ -80,7 +80,7 @@ class SearchField implements Indexable
             'tag_keywords' => new Search\FieldType\MultipleStringField(),
             'parent_tag_ids' => new Search\FieldType\MultipleIntegerField(),
             'tag_ids' => new Search\FieldType\MultipleIntegerField(),
-            'tag_text' => new Search\FieldType\TextField(),
+            'tag_text' => new Search\FieldType\StringField(),
             'fulltext' => new Search\FieldType\FullTextField(),
         ];
     }


### PR DESCRIPTION
Since text type field in solr.xml configuration is definted as multiValued from ezplatform-solr-search-engine v1.4, tag_text field type needs to be defined as StringField instead TextField for sorting to work.