### PR TITLE
Fix error when creating a tag on Symfony 5.4

### DIFF
--- a/bundle/Form/Type/TagCreateType.php
+++ b/bundle/Form/Type/TagCreateType.php
@@ -35,7 +35,7 @@ final class TagCreateType extends AbstractType
                 'label' => 'tag.parent_tag',
                 // Disable constraints specified in TagTreeType, since
                 // they are validated in TagCreateStructConstraint
-                'constraints' => null,
+                'constraints' => [],
             ]
         );
     }


### PR DESCRIPTION
As reported in issue #146, trying to create a new tag when using Symfony 5.4 throws an error. In Symfony 5.4, a change was introduced that limited the `constraints` option for a form field to be either a constraint object, or an array of constraint objects. Therefore, using `null` now throws an error.

This pull request fixes that error by replacing the `null` with an empty array, `[]`.