### PR TITLE
Fix create tags on content edit

### DIFF
--- a/bundle/API/Repository/Values/Tags/Tag.php
+++ b/bundle/API/Repository/Values/Tags/Tag.php
@@ -78,7 +78,7 @@ final class Tag extends ValueObject
     /**
      * A global unique ID of the tag.
      */
-    protected string $remoteId;
+    protected ?string $remoteId;
 
     /**
      * Indicates if the Tag object is shown in the main language if it is not present in an other requested language.

--- a/bundle/API/Repository/Values/Tags/Tag.php
+++ b/bundle/API/Repository/Values/Tags/Tag.php
@@ -33,7 +33,7 @@ final class Tag extends ValueObject
     /**
      * Tag ID.
      */
-    protected int $id;
+    protected ?int $id = null;
 
     /**
      * Parent tag ID.

--- a/bundle/Core/FieldType/Tags/Type.php
+++ b/bundle/Core/FieldType/Tags/Type.php
@@ -114,7 +114,7 @@ final class Type extends FieldType
                         'parentTagId' => $hashItem['parent_id'],
                         'keywords' => $hashItem['keywords'],
                         'mainLanguageCode' => $hashItem['main_language_code'],
-                        'remoteId' => $hashItem['remote_id'] ?? md5(uniqid(static::class, true)),
+                        'remoteId' => $hashItem['remote_id'] ?? null,
                         'alwaysAvailable' => $hashItem['always_available'] ?? true,
                     ]
                 );

--- a/bundle/Core/FieldType/Tags/Type.php
+++ b/bundle/Core/FieldType/Tags/Type.php
@@ -114,7 +114,7 @@ final class Type extends FieldType
                         'parentTagId' => $hashItem['parent_id'],
                         'keywords' => $hashItem['keywords'],
                         'mainLanguageCode' => $hashItem['main_language_code'],
-                        'remoteId' => $hashItem['remote_id'] ?? null,
+                        'remoteId' => $hashItem['remote_id'] ?? md5(uniqid(static::class, true)),
                         'alwaysAvailable' => $hashItem['always_available'] ?? true,
                     ]
                 );


### PR DESCRIPTION
Fix 2 errors : 
When I add new tags during content editing : 
  - remote_id can't be null (sorry I duplicate in ugly way md5 generation)
  - Typed property must not be accessed before initialization id
 