### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .idea/
 .tmp/
 coverage/
-extension/
 node_modules/
 /vendor/
 var/


### PR DESCRIPTION
I assume that's a left over from legacy. It puts the twig extension on the ignore list - most likely not intended.