### PR TITLE
New Criterion "TagSubtree" matching the "path_string" of tags

### DIFF
--- a/bundle/API/Repository/Values/Content/Query/Criterion/TagSubtree.php
+++ b/bundle/API/Repository/Values/Content/Query/Criterion/TagSubtree.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\TagsBundle\API\Repository\Values\Content\Query\Criterion;
+
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Operator;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+
+/**
+ * A criterion that matches content based on tag subtree that is located in one of the fields.
+ *
+ * Supported operators:
+ * - EQ: matches against one tag ID
+ */
+final class TagSubtree extends Criterion
+{
+    /**
+     * @param int|int[] $value One or more tag IDs that must be matched
+     * @param string|null $target Field definition identifier to use
+     */
+    public function __construct($value, ?string $target = null)
+    {
+        parent::__construct($target, null, $value);
+    }
+
+    public function getSpecifications(): array
+    {
+        return [
+            new Specifications(
+                Operator::EQ,
+                Specifications::FORMAT_SINGLE,
+                Specifications::TYPE_INTEGER | Specifications::TYPE_STRING
+            ),
+        ];
+    }
+}

--- a/bundle/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/Tags/TagSubtree.php
+++ b/bundle/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/Tags/TagSubtree.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\TagsBundle\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\Tags;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion;
+use Ibexa\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use Netgen\TagsBundle\API\Repository\Values\Content\Query\Criterion\TagSubtree as TagSubtreeCriterion;
+use Netgen\TagsBundle\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\Tags;
+
+final class TagSubtree extends Tags
+{
+    public function accept(Criterion $criterion): bool
+    {
+        return $criterion instanceof TagSubtreeCriterion;
+    }
+
+    public function handle(CriteriaConverter $converter, QueryBuilder $queryBuilder, Criterion $criterion, array $languageSettings): string
+    {
+        $subSelect = $this->connection->createQueryBuilder();
+        $subSelect
+            ->select('t1.id')
+            ->from('ezcontentobject', 't1')
+            ->innerJoin(
+                't1',
+                'eztags_attribute_link',
+                't2',
+                $queryBuilder->expr()->andX(
+                    $queryBuilder->expr()->eq('t2.objectattribute_version', 't1.current_version'),
+                    $queryBuilder->expr()->eq('t2.object_id', 't1.id')
+                )
+			)
+			->innerJoin(
+				't2',
+				'eztags',
+				't3',
+				$queryBuilder->expr()->eq( 't2.keyword_id', 't3.id' )
+            )->where(
+                $queryBuilder->expr()->like(
+                    't3.path_string',
+					$queryBuilder->createNamedParameter( '%/'. $criterion->value[0] .'/%' )
+                )
+            );
+
+        $fieldDefinitionIds = $this->getSearchableFields($criterion->target);
+        if ($fieldDefinitionIds !== null) {
+            $subSelect->innerJoin(
+                't2',
+                'ezcontentobject_attribute',
+                't3',
+                $queryBuilder->expr()->andX(
+                    $queryBuilder->expr()->eq('t3.id', 't2.objectattribute_id'),
+                    $queryBuilder->expr()->eq('t3.version', 't2.objectattribute_version')
+                )
+            )->andWhere(
+                $queryBuilder->expr()->in(
+                    't3.contentclassattribute_id',
+                    $queryBuilder->createNamedParameter($fieldDefinitionIds, Connection::PARAM_INT_ARRAY)
+                )
+            );
+        }
+
+        return $queryBuilder->expr()->in('c.id', $subSelect->getSQL());
+    }
+}

--- a/bundle/Resources/config/search/legacy.yaml
+++ b/bundle/Resources/config/search/legacy.yaml
@@ -1,4 +1,11 @@
 services:
+    netgen_tags.search.legacy.gateway.criterion_handler.common.tag_subtree:
+        class: Netgen\TagsBundle\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\Tags\TagSubtree
+        parent: ibexa.search.legacy.gateway.criterion_handler.base
+        tags:
+            - { name: ibexa.search.legacy.gateway.criterion_handler.content }
+            - { name: ibexa.search.legacy.gateway.criterion_handler.location }
+
     netgen_tags.search.legacy.gateway.criterion_handler.common.tag_id:
         class: Netgen\TagsBundle\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\Tags\TagId
         parent: ibexa.search.legacy.gateway.criterion_handler.base


### PR DESCRIPTION
Hi,

for a client project we need to be able to filter by a tag subtree. For example, there is a parent tag called "Category" and there are multiple children tags like "USA", "World" etc.
The content objects only have the tags "USA" or "World" assigned (not the "Category" tag).
We want to be able to find/filter all content that has any children tags of the "Category" tag.

Therefore I developed a new custom Criterion matching values against the DB field "eztags.path_string". Is that something you consider to add to the official repo?