### PR TITLE
NGSTACK-794 add check if tags field is actually required before valid…

### DIFF
--- a/bundle/Resources/public/admin/js/fieldType/eztags.js
+++ b/bundle/Resources/public/admin/js/fieldType/eztags.js
@@ -1,10 +1,12 @@
 (function (global, doc, ibexa) {
-    const SELECTOR_FIELD = '.ibexa-field-edit--eztags.ibexa-field-edit--required';
+    const SELECTOR_FIELD = '.ibexa-field-edit--eztags';
 
     class TagsValidator extends ibexa.BaseFieldValidator {
-            validateTags(event) {
+        validateTags(event) {
+            const fieldContainer = event.currentTarget.closest(SELECTOR_FIELD);
+            const isRequired = fieldContainer && fieldContainer.classList.contains('ibexa-field-edit--required');
             const isEmpty = !event.target.value;
-            const isError = isEmpty;
+            const isError = isRequired && isEmpty;
             const label = event.target.closest(SELECTOR_FIELD).querySelector('.ibexa-field-edit__label').innerHTML;
             const result = {isError};
             if (isEmpty) {


### PR DESCRIPTION
`SELECTOR_FIELD` was defined with required class, now it has been removed to be more in line with ibexa's way of selecting elements, where required class is checked inside the actual validator function.

This was also breaking selection of the label element, because not all tag container elements have required class on them